### PR TITLE
Fix npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "src/index.ts",
   "scripts": {
     "start": "npm run build && nodemon",
-    "watch-tsoa": "nodemon -x tsoa spec-and-routes",
     "test": "tsoa spec-and-routes && jest ./src --verbose",
     "lint": "npx eslint src --ext .ts",
     "build": "tsoa spec-and-routes && tsc --project tsconfig.json",


### PR DESCRIPTION
## Type of change
* [x] Fix
* [ ] Story
* [ ] Chore

## Description of the change
npm start crashes if we dont't run build before, therefore the concurrency in the npm run start command was eliminated

