### PR TITLE
fix: Update logout params from user id to access token

### DIFF
--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -31,7 +31,7 @@ export class AuthController extends Controller {
   @Post('/logout')
   @Security('jwt')
   public async logout(@Request() req: AuthenticatedRequest): Promise<void> {
-    await AuthService.logout(req.user.id);
+    await AuthService.logout(req.user.token);
     this.setStatus(httpStatus.OK);
   }
 

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -25,7 +25,10 @@ export function expressAuthentication(
             reject(new ApiError(errors.INVALID_TOKEN));
           }
         }
-        resolve(decoded.user);
+        resolve({
+          ...decoded.user,
+          token,
+        });
       });
     });
   }

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -1,4 +1,4 @@
 import { Request } from 'express';
 import { ReturnUser } from 'types/user';
 
-export type AuthenticatedRequest = Request & { user: ReturnUser };
+export type AuthenticatedRequest = Request & { user: ReturnUser & { token: string } };


### PR DESCRIPTION
## Notion Ticket
* [Fix logout endpoint](https://www.notion.so/xmartlabs/a755bd80b2bf4d8087fda94e9dfc7371?v=2e2f6677d0da4067b1998b81bd542339&p=98c72d48a6844297892f1a325127a67d&pm=s)

## Type of change
* [X] Fix
* [ ] Story
* [ ] Chore

## Description of the change
Logout endpoint used `userId` instead of `accessToken` to delete a session

