### PR TITLE
chore:Remove createdAt and updatedAt fields from endpoint

### DIFF
--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -8,9 +8,13 @@ import {
   Security,
 } from 'tsoa';
 import { AuthService } from 'services/auth';
-import { CreateUserParams, ReturnAuth, RefreshTokenParams } from 'types';
-import { LoginParams } from 'types/auth';
-import { AuthenticatedRequest } from 'types/request';
+import {
+  CreateUserParams,
+  ReturnAuth,
+  RefreshTokenParams,
+  AuthenticatedRequest,
+  LoginParams,
+} from 'types';
 
 @Route('auth')
 export class AuthController extends Controller {

--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -4,9 +4,7 @@ import {
   Controller, Delete, Get, Path, Put, Request, Route, Security,
 } from 'tsoa';
 import { UserService } from 'services';
-import { AuthenticatedRequest } from 'types/request';
-import { ReturnUser } from 'types';
-import { UpdateUserParams } from 'types/user';
+import { ReturnUser, UpdateUserParams, AuthenticatedRequest } from 'types';
 
 @Route('users')
 export class UsersController extends Controller {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -7,7 +7,7 @@ import {
   ReturnUser,
   LoginParams,
   RefreshTokenParams,
-} from 'types/index';
+} from 'types';
 import prisma from 'root/prisma/client';
 import { ApiError } from 'utils/apiError';
 import { errors } from 'config/errors';

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,12 +1,16 @@
 import * as bcrypt from 'bcryptjs';
-import { Prisma, User } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import prisma from 'root/prisma/client';
 import { ApiError } from 'utils/apiError';
-import { ReturnUser, CreateUserParams } from 'types';
+import {
+  ReturnUser,
+  CreateUserParams,
+  UpdateUserParams,
+  DatabaseUser,
+} from 'types';
 import { sendUserWithoutPassword, startSendEmailTask } from 'utils/user';
 import { emailRegex } from 'utils/constants';
 import { errors } from 'config/errors';
-import { UpdateUserParams } from 'types/user';
 
 export class UserService {
   static find = async (id : string) : Promise<ReturnUser | null> => {
@@ -17,12 +21,15 @@ export class UserService {
     return sendUserWithoutPassword(user);
   };
 
-  static all = () : Promise<User[]> => (prisma.user.findMany());
+  static all = async () : Promise<ReturnUser[]> => {
+    const users = await prisma.user.findMany();
+    return users.map(sendUserWithoutPassword);
+  };
 
   static create = async (userBody : CreateUserParams) : Promise<ReturnUser> => {
     const { name, email, password } = userBody;
 
-    let user: User | null = null;
+    let user: DatabaseUser | null = null;
 
     // Check if email is valid (from email-validator library)
     if (!emailRegex.test(email)) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,10 @@
 export { Config, ErrorInterface } from 'types/config';
-export { ReturnUser, CreateUserParams } from 'types/user';
+export {
+  ReturnUser,
+  CreateUserParams,
+  UpdateUserParams,
+  DatabaseUser,
+} from 'types/user';
 export { Wrapper } from 'types/middlewares';
 export { ReturnAuth, LoginParams, RefreshTokenParams } from 'types/auth';
+export { AuthenticatedRequest } from 'types/request';

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,4 +1,13 @@
-import { User } from '@prisma/client';
+export { User as DatabaseUser } from '@prisma/client';
+
+type User = {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  email: string;
+  password: string;
+  name: string | null;
+};
 
 export type ReturnUser = Omit<User, 'password'>;
 

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,10 +1,9 @@
 import cron from 'node-cron';
-import { ReturnUser } from 'types';
-import { User } from '@prisma/client';
+import { ReturnUser, DatabaseUser } from 'types';
 import { sendSignUpEmail } from 'emails';
 import { config } from 'config/config';
 
-export const sendUserWithoutPassword = (user : User) : ReturnUser => {
+export const sendUserWithoutPassword = (user : DatabaseUser) : ReturnUser => {
   const { password, ...userWithoutPassword } = user;
   return userWithoutPassword;
 };


### PR DESCRIPTION
## Type of change
* [X] Fix
* [ ] Story
* [ ] Chore

## Description of the change
Don't ask for `createdAt` and `updatedAt` fields in register and updated user endpoints, also don't ask for `id` field in update user endpoint.